### PR TITLE
chore: naming

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sonm-io/core/toolz/sonm-monitoring/aggregator"
 	"github.com/sonm-io/core/toolz/sonm-monitoring/collector"
 	"github.com/sonm-io/core/toolz/sonm-monitoring/discovery"
-	"github.com/sonm-io/core/toolz/sonm-monitoring/exporter"
+	"github.com/sonm-io/core/toolz/sonm-monitoring/influx"
 	"github.com/sonm-io/core/toolz/sonm-monitoring/types"
 	"github.com/sonm-io/core/util"
 	"github.com/sonm-io/core/util/debug"
@@ -24,7 +24,7 @@ import (
 )
 
 type Config struct {
-	Exporter  exporter.Config    `yaml:"exporter"`
+	Influx    influx.Config      `yaml:"influx"`
 	Collector collector.Config   `yaml:"collector"`
 	Eth       accounts.EthConfig `yaml:"ethereum"`
 	NPP       npp.Config         `yaml:"npp"`
@@ -70,17 +70,16 @@ func main() {
 	defer rot.Close()
 	creds := xgrpc.NewTransportCredentials(tlsConfig)
 
-	// exporto is InfluxDB adapter
-	exporto, err := exporter.NewExporter(&cfg.Exporter)
+	inf, err := influx.NewInfluxClient(&cfg.Influx)
 	if err != nil {
 		log.Fatal("failed to create exporter instance", zap.Error(err))
 		return
 	}
-	defer exporto.Close()
+	defer inf.Close()
 
 	// aggregator reading data from InfluxDB and aggregating
 	// various metrics
-	aggr := aggregator.NewAggregator(log, exporto)
+	aggr := aggregator.NewAggregator(log, inf)
 
 	// discovery service is obtaining info about online peers in SONM network
 	disco, err := discovery.NewRendezvousDiscovery(ctx, log, creds, cfg.NPP)
@@ -89,7 +88,7 @@ func main() {
 	}
 
 	// collector querying peers for various hardware (and software in closest future) metrics
-	collectro, err := collector.NewMetricsCollector(log, pkey, creds, cfg.NPP, cfg.Collector, exporto, disco)
+	collectro, err := collector.NewMetricsCollector(log, pkey, creds, cfg.NPP, cfg.Collector, inf, disco)
 	if err != nil {
 		log.Fatal("failed to create collector service", zap.Error(err))
 	}

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestCalculatePercent(t *testing.T) {
-	ld := &metricsLoader{}
+	ld := &workerMetricsCollector{}
 
 	input := map[string]float64{
 		sonm.MetricsKeyDiskTotal: 1000,

--- a/etc/collector.yaml
+++ b/etc/collector.yaml
@@ -1,12 +1,17 @@
 # Exported settings describes connection parameters for influxdb
-exporter:
+influx:
   # URL of influxdb instance
   db_addr: "http://localhost:8086"
   # name of the database to store metrics
   db_name: "sonm"
 
 collector:
+  # attach logger to npp dialer.
+  # heavily increases the number of log lines per connect,
+  # but allows to observe how does NPP works.
   verbose_dialer_logs: false
+  # serialize dialer metrics and save into file in /tmp/,
+  # it may help to debug various metrics calculation bugs.
   save_dialer_metrics_to_file: false
 
 # Settings for Ethereum keys


### PR DESCRIPTION
* Exporter (both package and type) was renamed to `Influx`.
* `metricsLoader` struct was renamed to `workerMetricsCollector`.